### PR TITLE
geom_alt props

### DIFF
--- a/data/101/767/415/101767415.geojson
+++ b/data/101/767/415/101767415.geojson
@@ -210,6 +210,9 @@
         "wd:id":"Q4540"
     },
     "wof:country":"LI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e8481e56d9aea1f452b6c89a1d153f6a",
     "wof:hierarchy":[
         {
@@ -224,7 +227,7 @@
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1566594107,
+    "wof:lastmodified":1582343858,
     "wof:name":"Eschen",
     "wof:parent_id":404473645,
     "wof:placetype":"locality",

--- a/data/101/767/417/101767417.geojson
+++ b/data/101/767/417/101767417.geojson
@@ -206,6 +206,9 @@
         "wk:page":"Balzers"
     },
     "wof:country":"LI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ee929a2c5968b8b7f787b1e5df5172b3",
     "wof:hierarchy":[
         {
@@ -220,7 +223,7 @@
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1566594107,
+    "wof:lastmodified":1582343858,
     "wof:name":"Balzers",
     "wof:parent_id":404473643,
     "wof:placetype":"locality",

--- a/data/101/828/603/101828603.geojson
+++ b/data/101/828/603/101828603.geojson
@@ -640,6 +640,9 @@
         "wk:page":"Vaduz"
     },
     "wof:country":"LI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cc7b9a0e3f3a8462e252b24526924d24",
     "wof:hierarchy":[
         {
@@ -654,7 +657,7 @@
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1566594107,
+    "wof:lastmodified":1582343858,
     "wof:megacity":0,
     "wof:name":"Vaduz",
     "wof:parent_id":404473641,

--- a/data/101/828/605/101828605.geojson
+++ b/data/101/828/605/101828605.geojson
@@ -205,6 +205,9 @@
         "wk:page":"Triesen"
     },
     "wof:country":"LI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5922c7bd87b8d2272942e4bf386313c6",
     "wof:hierarchy":[
         {
@@ -219,7 +222,7 @@
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1566594107,
+    "wof:lastmodified":1582343858,
     "wof:name":"Triesen",
     "wof:parent_id":404473633,
     "wof:placetype":"locality",

--- a/data/856/332/67/85633267.geojson
+++ b/data/856/332/67/85633267.geojson
@@ -1033,8 +1033,9 @@
     "qs:source":"SwissTopo",
     "src:geom":"whosonfirst",
     "src:geom_alt":[
-        "quattroshapes",
-        "naturalearth"
+        "naturalearth",
+        "naturalearth",
+        "quattroshapes"
     ],
     "src:geom_via":"quattroshapes",
     "src:lbl_centroid":"mapshaper",
@@ -1089,6 +1090,11 @@
     },
     "wof:country":"LI",
     "wof:country_alpha3":"LIE",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth",
+        "quattroshapes"
+    ],
     "wof:geomhash":"b8f7bf9366262fefbc47214e790a249a",
     "wof:hierarchy":[
         {
@@ -1105,7 +1111,7 @@
         "deu",
         "gsw"
     ],
-    "wof:lastmodified":1566594103,
+    "wof:lastmodified":1582343858,
     "wof:name":"Liechtenstein",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/332/67/85633267.geojson
+++ b/data/856/332/67/85633267.geojson
@@ -1034,7 +1034,6 @@
     "src:geom":"whosonfirst",
     "src:geom_alt":[
         "naturalearth",
-        "naturalearth",
         "quattroshapes"
     ],
     "src:geom_via":"quattroshapes",
@@ -1111,7 +1110,7 @@
         "deu",
         "gsw"
     ],
-    "wof:lastmodified":1582343858,
+    "wof:lastmodified":1583222821,
     "wof:name":"Liechtenstein",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/859/015/49/85901549.geojson
+++ b/data/859/015/49/85901549.geojson
@@ -73,6 +73,9 @@
         "qs_pg:id":42893
     },
     "wof:country":"LI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6d5552383f4154a8090e4d8a6d4fb6ed",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1566594103,
+    "wof:lastmodified":1582343858,
     "wof:name":"Mittlerer Schellenberg",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/015/51/85901551.geojson
+++ b/data/859/015/51/85901551.geojson
@@ -147,6 +147,9 @@
         "wk:page":"Hinterschellenberg"
     },
     "wof:country":"LI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"51d43fe8b50daaec644816f7cd739cf6",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1566594103,
+    "wof:lastmodified":1582343858,
     "wof:name":"Hinterer Schellenberg",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.