### PR TITLE
Name updates

### DIFF
--- a/data/112/576/841/9/1125768419.geojson
+++ b/data/112/576/841/9/1125768419.geojson
@@ -26,7 +26,7 @@
         "\u0634\u0627\u0646 \u060c \u0644\u064a\u062e\u062a\u0646\u0634\u062a\u0627\u064a\u0646"
     ],
     "name:ara_x_variant":[
-        "\u0634\u0627\u0646 "
+        "\u0634\u0627\u0646"
     ],
     "name:arg_x_preferred":[
         "Schaan"
@@ -246,8 +246,8 @@
     "woe:placetype":"Town",
     "wof:belongsto":[
         102191581,
-        404473639,
         85633267,
+        404473639,
         85685737
     ],
     "wof:breaches":[],
@@ -270,7 +270,7 @@
         }
     ],
     "wof:id":1125768419,
-    "wof:lastmodified":1566594110,
+    "wof:lastmodified":1587163113,
     "wof:name":"Schaan",
     "wof:parent_id":404473639,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.