### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/101/767/415/101767415.geojson
+++ b/data/101/767/415/101767415.geojson
@@ -23,7 +23,13 @@
     "name:als_x_preferred":[
         "Eschen"
     ],
+    "name:ara_x_preferred":[
+        "\u0625\u0634\u0646"
+    ],
     "name:arg_x_preferred":[
+        "Eschen"
+    ],
+    "name:ast_x_preferred":[
         "Eschen"
     ],
     "name:aze_x_preferred":[
@@ -74,6 +80,9 @@
     "name:fra_x_preferred":[
         "Eschen"
     ],
+    "name:frr_x_preferred":[
+        "Eschen"
+    ],
     "name:glg_x_preferred":[
         "Eschen"
     ],
@@ -88,6 +97,9 @@
     ],
     "name:hun_x_preferred":[
         "Eschen"
+    ],
+    "name:hye_x_preferred":[
+        "\u0531\u0577\u0565\u0576"
     ],
     "name:ile_x_preferred":[
         "Eschen"
@@ -117,6 +129,9 @@
         "\u0415\u0448\u0435\u043d"
     ],
     "name:msa_x_preferred":[
+        "Eschen"
+    ],
+    "name:nan_x_preferred":[
         "Eschen"
     ],
     "name:nld_x_preferred":[
@@ -158,6 +173,9 @@
     "name:slk_x_preferred":[
         "Eschen"
     ],
+    "name:smn_x_preferred":[
+        "Eschen"
+    ],
     "name:spa_x_preferred":[
         "Eschen"
     ],
@@ -179,10 +197,16 @@
     "name:urd_x_preferred":[
         "\u0627\u06cc\u0633\u0686\u0646"
     ],
+    "name:vec_x_preferred":[
+        "Eschen"
+    ],
     "name:vie_x_preferred":[
         "Eschen"
     ],
     "name:vol_x_preferred":[
+        "Eschen"
+    ],
+    "name:war_x_preferred":[
         "Eschen"
     ],
     "name:zho_x_preferred":[
@@ -239,7 +263,7 @@
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1636500463,
+    "wof:lastmodified":1690938529,
     "wof:name":"Eschen",
     "wof:parent_id":404473645,
     "wof:placetype":"locality",

--- a/data/101/767/417/101767417.geojson
+++ b/data/101/767/417/101767417.geojson
@@ -29,6 +29,9 @@
     "name:arg_x_preferred":[
         "Balzers"
     ],
+    "name:ast_x_preferred":[
+        "Balzers"
+    ],
     "name:aze_x_preferred":[
         "Bal\u00e7ers"
     ],
@@ -53,6 +56,9 @@
     "name:deu_x_preferred":[
         "Balzers"
     ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03ac\u03bb\u03c4\u03c3\u03b5\u03c1\u03c2"
+    ],
     "name:eng_x_preferred":[
         "Balzers"
     ],
@@ -71,6 +77,9 @@
     "name:fra_x_preferred":[
         "Balzers"
     ],
+    "name:frr_x_preferred":[
+        "Balzers"
+    ],
     "name:glg_x_preferred":[
         "Balzers"
     ],
@@ -84,6 +93,9 @@
         "\u092c\u093e\u0932\u094d\u091c\u093c\u0930\u094d\u0938"
     ],
     "name:hrv_x_preferred":[
+        "Balzers"
+    ],
+    "name:hun_x_preferred":[
         "Balzers"
     ],
     "name:ind_x_preferred":[
@@ -113,6 +125,9 @@
     "name:msa_x_preferred":[
         "Balzers"
     ],
+    "name:nan_x_preferred":[
+        "Balzers"
+    ],
     "name:nau_x_preferred":[
         "Balzers"
     ],
@@ -140,6 +155,9 @@
     "name:por_x_preferred":[
         "Balzers"
     ],
+    "name:pus_x_preferred":[
+        "\u0628\u0627\u0644\u0632\u0631\u0633"
+    ],
     "name:roh_x_preferred":[
         "Balzers"
     ],
@@ -153,6 +171,9 @@
         "Balzers"
     ],
     "name:slk_x_preferred":[
+        "Balzers"
+    ],
+    "name:smn_x_preferred":[
         "Balzers"
     ],
     "name:spa_x_preferred":[
@@ -170,14 +191,29 @@
     "name:ukr_x_preferred":[
         "\u0411\u0430\u043b\u044c\u0446\u0435\u0440\u0441"
     ],
+    "name:urd_x_preferred":[
+        "\u0628\u0627\u0644\u0632\u0631\u0633"
+    ],
+    "name:vec_x_preferred":[
+        "Balzers"
+    ],
     "name:vie_x_preferred":[
         "Balzers"
     ],
     "name:vol_x_preferred":[
         "Balzers"
     ],
+    "name:war_x_preferred":[
+        "Balzers"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5df4\u5c14\u7b56\u65af"
+    ],
     "name:zho_x_preferred":[
         "\u5df4\u5c14\u91c7\u65af"
+    ],
+    "name:zho_x_variant":[
+        "\u5df4\u5c14\u7b56\u65af"
     ],
     "qs:a0":"Liechtenstein",
     "qs:a1":"*",
@@ -232,7 +268,7 @@
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1636500464,
+    "wof:lastmodified":1690938529,
     "wof:name":"Balzers",
     "wof:parent_id":404473643,
     "wof:placetype":"locality",

--- a/data/101/828/603/101828603.geojson
+++ b/data/101/828/603/101828603.geojson
@@ -23,11 +23,17 @@
     "name:afr_x_preferred":[
         "Vaduz"
     ],
+    "name:aka_x_preferred":[
+        "Vaduz"
+    ],
     "name:als_x_preferred":[
         "Vaduz"
     ],
     "name:amh_x_preferred":[
         "\u134b\u12f1\u133d"
+    ],
+    "name:ang_x_preferred":[
+        "\u0112adus"
     ],
     "name:ara_x_preferred":[
         "\u0641\u0627\u062f\u0648\u0632"
@@ -38,6 +44,9 @@
     "name:arg_x_preferred":[
         "Vaduz"
     ],
+    "name:ary_x_preferred":[
+        "\u06a4\u0627\u062f\u0648\u0632"
+    ],
     "name:arz_x_preferred":[
         "\u0641\u0627\u062f\u0648\u0633"
     ],
@@ -47,8 +56,14 @@
     "name:ava_x_preferred":[
         "\u0412\u0430\u0434\u0443\u0446"
     ],
+    "name:avk_x_preferred":[
+        "Vaduz"
+    ],
     "name:aze_x_preferred":[
         "Vaduts"
+    ],
+    "name:ban_x_preferred":[
+        "Vaduz"
     ],
     "name:bcl_x_preferred":[
         "Vaduz"
@@ -91,6 +106,9 @@
     ],
     "name:che_x_preferred":[
         "\u0412\u0430\u0434\u0443\u0446"
+    ],
+    "name:chu_x_preferred":[
+        "\u0412\u0430\u0434\u043e\u0443\u0446\u044c"
     ],
     "name:chv_x_preferred":[
         "\u0412\u0430\u0434\u0443\u0446"
@@ -135,6 +153,9 @@
         "Vaduz"
     ],
     "name:ext_x_preferred":[
+        "Vaduz"
+    ],
+    "name:fao_x_preferred":[
         "Vaduz"
     ],
     "name:fas_x_preferred":[
@@ -221,6 +242,9 @@
     "name:ile_x_preferred":[
         "Vaduz"
     ],
+    "name:ina_x_preferred":[
+        "Vaduz"
+    ],
     "name:ind_x_preferred":[
         "Vaduz"
     ],
@@ -254,11 +278,17 @@
     "name:kor_x_preferred":[
         "\ud30c\ub450\uce20"
     ],
+    "name:kur_x_preferred":[
+        "Vaduz"
+    ],
     "name:lat_x_preferred":[
         "Dulcis Vallis"
     ],
     "name:lav_x_preferred":[
         "Vaduca"
+    ],
+    "name:lfn_x_preferred":[
+        "Vaduz"
     ],
     "name:lij_x_preferred":[
         "Vadus"
@@ -290,6 +320,9 @@
     "name:mar_x_preferred":[
         "\u092b\u093e\u0921\u0941\u091f\u094d\u0938"
     ],
+    "name:mdf_x_preferred":[
+        "\u0412\u0430\u0434\u0443\u0446"
+    ],
     "name:mkd_x_preferred":[
         "\u0412\u0430\u0434\u0443\u0446"
     ],
@@ -311,6 +344,9 @@
     "name:myv_x_preferred":[
         "\u0412\u0430\u0434\u0443\u0446 \u043e\u0448"
     ],
+    "name:mzn_x_preferred":[
+        "\u0648\u0627\u062f\u0648\u062a\u0633"
+    ],
     "name:nah_x_preferred":[
         "Vaduz"
     ],
@@ -321,6 +357,9 @@
         "Vaduz"
     ],
     "name:nau_x_preferred":[
+        "Vaduz"
+    ],
+    "name:nds_x_preferred":[
         "Vaduz"
     ],
     "name:nld_x_preferred":[
@@ -374,6 +413,9 @@
     "name:ron_x_preferred":[
         "Vaduz"
     ],
+    "name:rue_x_preferred":[
+        "\u0412\u0430\u0434\u0443\u0446"
+    ],
     "name:rus_x_preferred":[
         "\u0412\u0430\u0434\u0443\u0446"
     ],
@@ -399,6 +441,9 @@
         "Vaduz"
     ],
     "name:sme_x_preferred":[
+        "Vaduz"
+    ],
+    "name:smn_x_preferred":[
         "Vaduz"
     ],
     "name:sna_x_preferred":[
@@ -445,6 +490,9 @@
     ],
     "name:tuk_x_preferred":[
         "Waduz"
+    ],
+    "name:tum_x_preferred":[
+        "Vaduz"
     ],
     "name:tur_x_preferred":[
         "Vaduz"
@@ -625,8 +673,8 @@
     "wd:wordcount":1145,
     "wof:belongsto":[
         102191581,
-        85633267,
         404473641,
+        85633267,
         85685737
     ],
     "wof:breaches":[],
@@ -659,7 +707,7 @@
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1607390890,
+    "wof:lastmodified":1690938529,
     "wof:megacity":0,
     "wof:name":"Vaduz",
     "wof:parent_id":404473641,

--- a/data/101/828/605/101828605.geojson
+++ b/data/101/828/605/101828605.geojson
@@ -23,7 +23,13 @@
     "name:als_x_preferred":[
         "Triesen"
     ],
+    "name:ara_x_preferred":[
+        "\u062a\u0631\u064a\u0633\u064a\u0646"
+    ],
     "name:arg_x_preferred":[
+        "Triesen"
+    ],
+    "name:ast_x_preferred":[
         "Triesen"
     ],
     "name:aze_x_preferred":[
@@ -77,6 +83,9 @@
     "name:fra_x_preferred":[
         "Triesen"
     ],
+    "name:frr_x_preferred":[
+        "Triesen"
+    ],
     "name:glg_x_preferred":[
         "Triesen"
     ],
@@ -116,6 +125,12 @@
     "name:mkd_x_preferred":[
         "\u0422\u0440\u0438\u0437\u0435\u043d"
     ],
+    "name:mon_x_preferred":[
+        "\u0422\u0440\u0438\u0439\u0437\u0435\u043d"
+    ],
+    "name:nan_x_preferred":[
+        "Triesen"
+    ],
     "name:nld_x_preferred":[
         "Triesen"
     ],
@@ -140,6 +155,9 @@
     "name:por_x_preferred":[
         "Triesen"
     ],
+    "name:pus_x_preferred":[
+        "\u062a\u0631\u06cc\u0632\u0646"
+    ],
     "name:roh_x_preferred":[
         "Triesen"
     ],
@@ -153,6 +171,9 @@
         "Triesen"
     ],
     "name:slk_x_preferred":[
+        "Triesen"
+    ],
+    "name:smn_x_preferred":[
         "Triesen"
     ],
     "name:spa_x_preferred":[
@@ -173,10 +194,16 @@
     "name:urd_x_preferred":[
         "\u0679\u0631\u0627\u0626\u06cc\u0633\u06cc\u0646"
     ],
+    "name:vec_x_preferred":[
+        "Triesen"
+    ],
     "name:vie_x_preferred":[
         "Triesen"
     ],
     "name:vol_x_preferred":[
+        "Triesen"
+    ],
+    "name:war_x_preferred":[
         "Triesen"
     ],
     "name:zho_x_preferred":[
@@ -234,7 +261,7 @@
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1636500463,
+    "wof:lastmodified":1690938529,
     "wof:name":"Triesen",
     "wof:parent_id":404473633,
     "wof:placetype":"locality",

--- a/data/112/576/841/9/1125768419.geojson
+++ b/data/112/576/841/9/1125768419.geojson
@@ -26,9 +26,13 @@
         "\u0634\u0627\u0646 \u060c \u0644\u064a\u062e\u062a\u0646\u0634\u062a\u0627\u064a\u0646"
     ],
     "name:ara_x_variant":[
-        "\u0634\u0627\u0646"
+        "\u0634\u0627\u0646",
+        "\u0634\u0627\u0646 "
     ],
     "name:arg_x_preferred":[
+        "Schaan"
+    ],
+    "name:ast_x_preferred":[
         "Schaan"
     ],
     "name:aze_x_preferred":[
@@ -36,6 +40,9 @@
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0428\u0430\u043d"
+    ],
+    "name:bel_x_variant":[
+        "\u0428\u0430\u043d"
     ],
     "name:ben_x_preferred":[
         "\u09b6\u09be\u09a8"
@@ -85,6 +92,9 @@
     "name:fra_x_preferred":[
         "Schaan"
     ],
+    "name:frr_x_preferred":[
+        "Schaan"
+    ],
     "name:gla_x_preferred":[
         "Schaan"
     ],
@@ -105,6 +115,9 @@
     ],
     "name:hun_x_preferred":[
         "Schaan"
+    ],
+    "name:hye_x_preferred":[
+        "\u0547\u0561\u0576"
     ],
     "name:ind_x_preferred":[
         "Schaan"
@@ -136,6 +149,9 @@
     "name:nah_x_preferred":[
         "Schaan"
     ],
+    "name:nan_x_preferred":[
+        "Schaan"
+    ],
     "name:nau_x_preferred":[
         "Schaan"
     ],
@@ -160,6 +176,9 @@
     "name:por_x_preferred":[
         "Schaan"
     ],
+    "name:pus_x_preferred":[
+        "\u0634\u0627\u0646"
+    ],
     "name:roh_x_preferred":[
         "Schaan"
     ],
@@ -181,6 +200,9 @@
     "name:slk_x_preferred":[
         "Schaan"
     ],
+    "name:smn_x_preferred":[
+        "Schaan"
+    ],
     "name:spa_x_preferred":[
         "Schaan"
     ],
@@ -199,6 +221,9 @@
     "name:ukr_x_preferred":[
         "\u0428\u0430\u043d"
     ],
+    "name:ukr_x_variant":[
+        "\u0428\u0430\u0430\u043d"
+    ],
     "name:und_x_variant":[
         "Schan"
     ],
@@ -207,6 +232,9 @@
     ],
     "name:urd_x_variant":[
         "\u0634\u0627\u0646"
+    ],
+    "name:vec_x_preferred":[
+        "Schaan"
     ],
     "name:vie_x_preferred":[
         "Schaan"
@@ -276,7 +304,7 @@
         }
     ],
     "wof:id":1125768419,
-    "wof:lastmodified":1636500464,
+    "wof:lastmodified":1690938531,
     "wof:name":"Schaan",
     "wof:parent_id":404473639,
     "wof:placetype":"locality",

--- a/data/112/578/389/9/1125783899.geojson
+++ b/data/112/578/389/9/1125783899.geojson
@@ -28,6 +28,9 @@
     "name:arg_x_preferred":[
         "Ruggell"
     ],
+    "name:ast_x_preferred":[
+        "Ruggell"
+    ],
     "name:bel_x_preferred":[
         "\u0420\u0443\u0433\u0435\u043b\u044c"
     ],
@@ -64,6 +67,9 @@
     "name:fas_x_preferred":[
         "\u0631\u0648\u06af\u0644"
     ],
+    "name:fin_x_preferred":[
+        "Ruggell"
+    ],
     "name:fra_x_preferred":[
         "Ruggell"
     ],
@@ -81,6 +87,12 @@
     ],
     "name:hin_x_preferred":[
         "\u0930\u0917\u094d\u0917\u0947\u0932"
+    ],
+    "name:hun_x_preferred":[
+        "Ruggell"
+    ],
+    "name:hye_x_preferred":[
+        "\u054c\u0578\u0582\u0563\u0563\u0565\u056c"
     ],
     "name:ind_x_preferred":[
         "Ruggell"
@@ -106,6 +118,9 @@
     "name:mkd_x_preferred":[
         "\u0420\u0443\u0433\u0435\u043b"
     ],
+    "name:nan_x_preferred":[
+        "Ruggell"
+    ],
     "name:nau_x_preferred":[
         "Ruggell"
     ],
@@ -130,6 +145,9 @@
     "name:por_x_preferred":[
         "Ruggell"
     ],
+    "name:pus_x_preferred":[
+        "\u0631\u0648\u06ab\u0644"
+    ],
     "name:roh_x_preferred":[
         "Ruggell"
     ],
@@ -143,6 +161,9 @@
         "Ruggell"
     ],
     "name:slk_x_preferred":[
+        "Ruggell"
+    ],
+    "name:smn_x_preferred":[
         "Ruggell"
     ],
     "name:spa_x_preferred":[
@@ -169,14 +190,23 @@
     "name:urd_x_preferred":[
         "\u0631\u06af\u06cc\u0644"
     ],
+    "name:vec_x_preferred":[
+        "Ruggell"
+    ],
     "name:vie_x_preferred":[
         "Ruggell"
     ],
     "name:vol_x_preferred":[
         "Ruggell"
     ],
+    "name:war_x_preferred":[
+        "Ruggell"
+    ],
     "name:zho_x_preferred":[
         "\u5112\u683c\u5c14"
+    ],
+    "name:zho_x_variant":[
+        "\u9c81\u683c\u5c14"
     ],
     "qs_pg:aaroncc":"LI",
     "qs_pg:gn_country":"LI",
@@ -217,7 +247,7 @@
         }
     ],
     "wof:id":1125783899,
-    "wof:lastmodified":1636500465,
+    "wof:lastmodified":1690938532,
     "wof:name":"Ruggell",
     "wof:parent_id":404473655,
     "wof:placetype":"locality",

--- a/data/112/578/391/3/1125783913.geojson
+++ b/data/112/578/391/3/1125783913.geojson
@@ -22,7 +22,13 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u062c\u0627\u0645\u0628\u0631\u064a\u0646"
+    ],
     "name:arg_x_preferred":[
+        "Gamprin"
+    ],
+    "name:ast_x_preferred":[
         "Gamprin"
     ],
     "name:bel_x_preferred":[
@@ -49,6 +55,9 @@
     "name:ell_x_preferred":[
         "\u0393\u03ba\u03b1\u03bc\u03c0\u03c1\u03af\u03bd"
     ],
+    "name:ell_x_variant":[
+        "\u0393\u03ba\u03ac\u03bc\u03c0\u03c1\u03b9\u03bd"
+    ],
     "name:eng_x_preferred":[
         "Gamprin"
     ],
@@ -61,7 +70,13 @@
     "name:fas_x_preferred":[
         "\u06af\u0645\u067e\u062e\u06cc\u0646"
     ],
+    "name:fin_x_preferred":[
+        "Gamprin"
+    ],
     "name:fra_x_preferred":[
+        "Gamprin"
+    ],
+    "name:frr_x_preferred":[
         "Gamprin"
     ],
     "name:glg_x_preferred":[
@@ -76,6 +91,9 @@
     "name:hin_x_preferred":[
         "\u0917\u0948\u092e\u094d\u092a\u094d\u0930\u0940\u0928"
     ],
+    "name:hun_x_preferred":[
+        "Gamprin"
+    ],
     "name:hye_x_preferred":[
         "\u0533\u0561\u0574\u057a\u0580\u056b\u0576"
     ],
@@ -87,6 +105,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30ac\u30f3\u30d7\u30ea\u30f3"
+    ],
+    "name:kaz_x_preferred":[
+        "\u0413\u0430\u043c\u043f\u0440\u0438\u043d"
     ],
     "name:kor_x_preferred":[
         "\uac10\ud504\ub9b0"
@@ -104,6 +125,9 @@
         "\u0413\u0430\u043c\u043f\u0440\u0438\u043d"
     ],
     "name:msa_x_preferred":[
+        "Gamprin"
+    ],
+    "name:nan_x_preferred":[
         "Gamprin"
     ],
     "name:nld_x_preferred":[
@@ -142,6 +166,9 @@
     "name:slk_x_preferred":[
         "Gamprin"
     ],
+    "name:smn_x_preferred":[
+        "Gamprin"
+    ],
     "name:spa_x_preferred":[
         "Gamprin"
     ],
@@ -166,10 +193,16 @@
     "name:urd_x_preferred":[
         "\u06af\u0627\u0645\u067e\u0631\u06cc\u0646"
     ],
+    "name:vec_x_preferred":[
+        "Gamprin"
+    ],
     "name:vie_x_preferred":[
         "Gamprin"
     ],
     "name:vol_x_preferred":[
+        "Gamprin"
+    ],
+    "name:war_x_preferred":[
         "Gamprin"
     ],
     "name:zho_x_preferred":[
@@ -214,7 +247,7 @@
         }
     ],
     "wof:id":1125783913,
-    "wof:lastmodified":1636500464,
+    "wof:lastmodified":1690938531,
     "wof:name":"Gamprin",
     "wof:parent_id":404473659,
     "wof:placetype":"locality",

--- a/data/112/591/326/7/1125913267.geojson
+++ b/data/112/591/326/7/1125913267.geojson
@@ -25,6 +25,9 @@
     "name:arg_x_preferred":[
         "Bendern"
     ],
+    "name:ast_x_preferred":[
+        "Bendern"
+    ],
     "name:bel_x_preferred":[
         "\u0411\u0435\u043d\u0434\u044d\u0440\u043d"
     ],
@@ -54,6 +57,9 @@
     ],
     "name:hye_x_preferred":[
         "\u0532\u0565\u0576\u0564\u0565\u0580\u0576"
+    ],
+    "name:kaz_x_preferred":[
+        "\u0411\u0435\u043d\u0434\u0435\u0440\u043d"
     ],
     "name:lmo_x_preferred":[
         "Bendern"
@@ -134,7 +140,7 @@
         }
     ],
     "wof:id":1125913267,
-    "wof:lastmodified":1566594110,
+    "wof:lastmodified":1690938530,
     "wof:name":"Bendern",
     "wof:parent_id":404473659,
     "wof:placetype":"locality",

--- a/data/112/592/115/3/1125921153.geojson
+++ b/data/112/592/115/3/1125921153.geojson
@@ -22,7 +22,13 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0628\u0644\u0627\u0646\u0643\u064a\u0646"
+    ],
     "name:arg_x_preferred":[
+        "Planken"
+    ],
+    "name:ast_x_preferred":[
         "Planken"
     ],
     "name:bel_x_preferred":[
@@ -67,6 +73,9 @@
     "name:fra_x_preferred":[
         "Planken"
     ],
+    "name:frr_x_preferred":[
+        "Planken"
+    ],
     "name:glg_x_preferred":[
         "Planken"
     ],
@@ -78,6 +87,12 @@
     ],
     "name:hin_x_preferred":[
         "\u092a\u094d\u0932\u0902\u0915\u0947\u0928"
+    ],
+    "name:hun_x_preferred":[
+        "Planken"
+    ],
+    "name:hye_x_preferred":[
+        "\u054a\u056c\u0561\u0576\u056f\u0565\u0576"
     ],
     "name:ind_x_preferred":[
         "Planken"
@@ -103,6 +118,9 @@
     "name:mkd_x_preferred":[
         "\u041f\u043b\u0430\u043d\u043a\u0435\u043d"
     ],
+    "name:nan_x_preferred":[
+        "Planken"
+    ],
     "name:nld_x_preferred":[
         "Planken"
     ],
@@ -124,6 +142,9 @@
     "name:por_x_preferred":[
         "Planken"
     ],
+    "name:pus_x_preferred":[
+        "\u067e\u0644\u0627\u0646\u06a9\u0646"
+    ],
     "name:roh_x_preferred":[
         "Planken"
     ],
@@ -137,6 +158,9 @@
         "Planken"
     ],
     "name:slk_x_preferred":[
+        "Planken"
+    ],
+    "name:smn_x_preferred":[
         "Planken"
     ],
     "name:spa_x_preferred":[
@@ -160,10 +184,16 @@
     "name:urd_x_preferred":[
         "\u067e\u0644\u0646\u06a9\u06cc\u0646"
     ],
+    "name:vec_x_preferred":[
+        "Planken"
+    ],
     "name:vie_x_preferred":[
         "Planken"
     ],
     "name:vol_x_preferred":[
+        "Planken"
+    ],
+    "name:war_x_preferred":[
         "Planken"
     ],
     "name:zho_x_preferred":[
@@ -222,7 +252,7 @@
         }
     ],
     "wof:id":1125921153,
-    "wof:lastmodified":1636500464,
+    "wof:lastmodified":1690938530,
     "wof:name":"Planken",
     "wof:parent_id":404473665,
     "wof:placetype":"locality",

--- a/data/112/596/267/5/1125962675.geojson
+++ b/data/112/596/267/5/1125962675.geojson
@@ -235,6 +235,9 @@
     "name:wol_x_preferred":[
         "Steg"
     ],
+    "name:zho_x_preferred":[
+        "\u65bd\u6cf0\u683c"
+    ],
     "name:zul_x_preferred":[
         "Steg"
     ],
@@ -291,7 +294,7 @@
         }
     ],
     "wof:id":1125962675,
-    "wof:lastmodified":1566594110,
+    "wof:lastmodified":1690938530,
     "wof:name":"Steg",
     "wof:parent_id":404473637,
     "wof:placetype":"locality",

--- a/data/112/599/466/1/1125994661.geojson
+++ b/data/112/599/466/1/1125994661.geojson
@@ -22,7 +22,13 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u062a\u0631\u064a\u0633\u0646\u0628\u064a\u0631\u062c"
+    ],
     "name:arg_x_preferred":[
+        "Triesenberg"
+    ],
+    "name:ast_x_preferred":[
         "Triesenberg"
     ],
     "name:bel_x_preferred":[
@@ -35,6 +41,9 @@
         "Triesenberg"
     ],
     "name:ceb_x_preferred":[
+        "Triesenberg"
+    ],
+    "name:ces_x_preferred":[
         "Triesenberg"
     ],
     "name:dan_x_preferred":[
@@ -67,6 +76,9 @@
     "name:fra_x_preferred":[
         "Triesenberg"
     ],
+    "name:frr_x_preferred":[
+        "Triesenberg"
+    ],
     "name:glg_x_preferred":[
         "Triesenberg"
     ],
@@ -78,6 +90,9 @@
     ],
     "name:hin_x_preferred":[
         "\u091f\u094d\u0930\u093e\u0907\u0938\u0947\u0928\u092c\u0930\u094d\u0917"
+    ],
+    "name:hun_x_preferred":[
+        "Triesenberg"
     ],
     "name:ind_x_preferred":[
         "Triesenberg"
@@ -103,6 +118,9 @@
     "name:mkd_x_preferred":[
         "\u0422\u0440\u0438\u0437\u0435\u043d\u0431\u0435\u0440\u0433"
     ],
+    "name:nan_x_preferred":[
+        "Triesenberg"
+    ],
     "name:nld_x_preferred":[
         "Triesenberg"
     ],
@@ -124,6 +142,9 @@
     "name:por_x_preferred":[
         "Triesenberg"
     ],
+    "name:pus_x_preferred":[
+        "\u062a\u0631\u06cc\u0632\u0646\u0628\u0631\u06ab"
+    ],
     "name:roh_x_preferred":[
         "Triesenberg"
     ],
@@ -137,6 +158,9 @@
         "Triesenberg"
     ],
     "name:slk_x_preferred":[
+        "Triesenberg"
+    ],
+    "name:smn_x_preferred":[
         "Triesenberg"
     ],
     "name:spa_x_preferred":[
@@ -163,10 +187,16 @@
     "name:urd_x_preferred":[
         "\u0679\u0631\u0627\u0626\u0633\u06cc\u0646 \u0628\u0631\u06af"
     ],
+    "name:vec_x_preferred":[
+        "Triesenberg"
+    ],
     "name:vie_x_preferred":[
         "Triesenberg"
     ],
     "name:vol_x_preferred":[
+        "Triesenberg"
+    ],
+    "name:war_x_preferred":[
         "Triesenberg"
     ],
     "name:zho_x_preferred":[
@@ -225,7 +255,7 @@
         }
     ],
     "wof:id":1125994661,
-    "wof:lastmodified":1636500464,
+    "wof:lastmodified":1690938530,
     "wof:name":"Triesenberg",
     "wof:parent_id":404473637,
     "wof:placetype":"locality",

--- a/data/112/600/364/9/1126003649.geojson
+++ b/data/112/600/364/9/1126003649.geojson
@@ -22,7 +22,13 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0634\u0644\u064a\u0646\u0628\u0631\u062c"
+    ],
     "name:arg_x_preferred":[
+        "Schellenberg"
+    ],
+    "name:ast_x_preferred":[
         "Schellenberg"
     ],
     "name:bel_x_preferred":[
@@ -30,6 +36,9 @@
     ],
     "name:ben_x_preferred":[
         "\u09b6\u09c7\u09b2\u09c7\u09a8\u09ac\u09be\u09b0\u09cd\u0997"
+    ],
+    "name:bul_x_preferred":[
+        "\u0428\u0435\u043b\u0435\u043d\u0431\u0435\u0440\u0433"
     ],
     "name:cat_x_preferred":[
         "Schellenberg"
@@ -88,6 +97,9 @@
     "name:hun_x_preferred":[
         "Schellenberg"
     ],
+    "name:hye_x_preferred":[
+        "\u0547\u0565\u056c\u0565\u0576\u0562\u0565\u0580\u0563"
+    ],
     "name:ind_x_preferred":[
         "Schellenberg"
     ],
@@ -111,6 +123,9 @@
     ],
     "name:mkd_x_preferred":[
         "\u0428\u0435\u043b\u0435\u043d\u0431\u0435\u0440\u0433"
+    ],
+    "name:nan_x_preferred":[
+        "Schellenberg"
     ],
     "name:nld_x_preferred":[
         "Schellenberg"
@@ -136,6 +151,9 @@
     "name:por_x_preferred":[
         "Schellenberg"
     ],
+    "name:pus_x_preferred":[
+        "\u0634\u06cc\u0644\u06cc\u0646\u0628\u0631\u06ab"
+    ],
     "name:roh_x_preferred":[
         "Schellenberg"
     ],
@@ -152,6 +170,9 @@
         "Schellenberg"
     ],
     "name:slk_x_preferred":[
+        "Schellenberg"
+    ],
+    "name:smn_x_preferred":[
         "Schellenberg"
     ],
     "name:spa_x_preferred":[
@@ -175,10 +196,16 @@
     "name:urd_x_preferred":[
         "\u0634\u0644\u0646\u0628\u0631\u06af"
     ],
+    "name:vec_x_preferred":[
+        "Schellenberg"
+    ],
     "name:vie_x_preferred":[
         "Schellenberg"
     ],
     "name:vol_x_preferred":[
+        "Schellenberg"
+    ],
+    "name:war_x_preferred":[
         "Schellenberg"
     ],
     "name:zho_x_preferred":[
@@ -223,7 +250,7 @@
         }
     ],
     "wof:id":1126003649,
-    "wof:lastmodified":1636500464,
+    "wof:lastmodified":1690938531,
     "wof:name":"Schellenberg",
     "wof:parent_id":404473663,
     "wof:placetype":"locality",

--- a/data/112/600/793/1/1126007931.geojson
+++ b/data/112/600/793/1/1126007931.geojson
@@ -25,7 +25,13 @@
     "name:ara_x_preferred":[
         "\u0645\u0648\u0631\u064a\u0646"
     ],
+    "name:ara_x_variant":[
+        "\u0628\u0644\u062f\u064a\u0629 \u0645\u0648\u0631\u064a\u0646"
+    ],
     "name:arg_x_preferred":[
+        "Mauren"
+    ],
+    "name:ast_x_preferred":[
         "Mauren"
     ],
     "name:bel_x_preferred":[
@@ -64,7 +70,13 @@
     "name:fas_x_preferred":[
         "\u0645\u0627\u0648\u0642\u0646"
     ],
+    "name:fin_x_preferred":[
+        "Mauren"
+    ],
     "name:fra_x_preferred":[
+        "Mauren"
+    ],
+    "name:frr_x_preferred":[
         "Mauren"
     ],
     "name:glg_x_preferred":[
@@ -79,6 +91,9 @@
     "name:hin_x_preferred":[
         "\u092e\u094c\u0930\u0947\u0928"
     ],
+    "name:hun_x_preferred":[
+        "Mauren"
+    ],
     "name:ind_x_preferred":[
         "Mauren"
     ],
@@ -87,6 +102,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30de\u30a6\u30ec\u30f3"
+    ],
+    "name:kaz_x_preferred":[
+        "\u041c\u0430\u0443\u0440\u0435\u043d"
     ],
     "name:kor_x_preferred":[
         "\ub9c8\uc6b0\ub80c"
@@ -104,6 +122,9 @@
         "\u041c\u0430\u0443\u0440\u0435\u043d"
     ],
     "name:msa_x_preferred":[
+        "Mauren"
+    ],
+    "name:nan_x_preferred":[
         "Mauren"
     ],
     "name:nld_x_preferred":[
@@ -142,6 +163,9 @@
     "name:slk_x_preferred":[
         "Mauren"
     ],
+    "name:smn_x_preferred":[
+        "Mauren"
+    ],
     "name:spa_x_preferred":[
         "Mauren"
     ],
@@ -163,10 +187,16 @@
     "name:urd_x_preferred":[
         "\u0645\u0627\u0648\u06cc\u0631\u0646"
     ],
+    "name:vec_x_preferred":[
+        "Mauren"
+    ],
     "name:vie_x_preferred":[
         "Mauren"
     ],
     "name:vol_x_preferred":[
+        "Mauren"
+    ],
+    "name:war_x_preferred":[
         "Mauren"
     ],
     "name:zho_x_preferred":[
@@ -223,7 +253,7 @@
         }
     ],
     "wof:id":1126007931,
-    "wof:lastmodified":1636500464,
+    "wof:lastmodified":1690938531,
     "wof:name":"Mauren",
     "wof:parent_id":404473651,
     "wof:placetype":"locality",

--- a/data/856/332/67/85633267.geojson
+++ b/data/856/332/67/85633267.geojson
@@ -44,6 +44,9 @@
     "name:abk_x_preferred":[
         "\u041b\u0438\u0445\u0442\u0435\u043d\u0448\u0442\u0430\u0438\u043d"
     ],
+    "name:abk_x_variant":[
+        "\u041b\u0438\u0445\u0442\u0435\u043d\u0448\u0442\u0435\u0438\u043d"
+    ],
     "name:ace_x_preferred":[
         "Liechtenstein"
     ],
@@ -52,6 +55,9 @@
     ],
     "name:aka_x_preferred":[
         "Lektenstaen"
+    ],
+    "name:aka_x_variant":[
+        "Liechtenstein"
     ],
     "name:als_x_preferred":[
         "Liechtenstein"
@@ -62,8 +68,17 @@
     "name:amh_x_variant":[
         "\u120a\u127d\u1270\u1295\u1235\u1273\u12ed\u1295"
     ],
+    "name:ami_x_preferred":[
+        "Liechtenstein"
+    ],
     "name:ang_x_preferred":[
         "L\u0113ohtenst\u0101n"
+    ],
+    "name:ang_x_variant":[
+        "Leohtenstan"
+    ],
+    "name:anp_x_preferred":[
+        "\u0932\u0940\u0916\u094d\u091f\u0947\u0928\u0936\u094d\u091f\u093e\u0907\u0928"
     ],
     "name:ara_x_preferred":[
         "\u0644\u064a\u062e\u062a\u0646\u0634\u062a\u0627\u064a\u0646"
@@ -74,6 +89,9 @@
     "name:arg_x_preferred":[
         "Liechtenstein"
     ],
+    "name:ary_x_preferred":[
+        "\u0644\u064a\u0634\u0637\u0646\u0634\u0637\u0627\u064a\u0646"
+    ],
     "name:arz_x_preferred":[
         "\u0644\u064a\u062e\u062a\u0646\u0634\u062a\u0627\u064a\u0646"
     ],
@@ -82,6 +100,12 @@
     ],
     "name:ava_x_preferred":[
         "\u041b\u0438\u0445\u0442\u0435\u043d\u0448\u0442\u0435\u0439\u043d"
+    ],
+    "name:avk_x_preferred":[
+        "Liectensteina"
+    ],
+    "name:awa_x_preferred":[
+        "\u0932\u0940\u0916\u093c\u094d\u091f\u0947\u0928\u094d\u0938\u094d\u091f\u093e\u0907\u0928"
     ],
     "name:azb_x_preferred":[
         "\u0644\u06cc\u062e\u062a\u0646 \u0627\u06cc\u0634\u062a\u0627\u06cc\u0646"
@@ -95,11 +119,17 @@
     "name:bam_x_preferred":[
         "Lis\u025bnsitayini"
     ],
+    "name:ban_x_preferred":[
+        "Liechtenstein"
+    ],
     "name:bar_x_preferred":[
         "Liachtnstoa"
     ],
     "name:bar_x_variant":[
         "Liechtnst\u00e2"
+    ],
+    "name:bcl_x_preferred":[
+        "Liechtenstein"
     ],
     "name:bel_x_preferred":[
         "\u041b\u0456\u0445\u0442\u044d\u043d\u0448\u0442\u044d\u0439\u043d"
@@ -180,6 +210,9 @@
         "Liechtenstein"
     ],
     "name:cym_x_preferred":[
+        "Liechtenstein"
+    ],
+    "name:dag_x_preferred":[
         "Liechtenstein"
     ],
     "name:dan_x_preferred":[
@@ -294,6 +327,9 @@
     "name:gag_x_preferred":[
         "Lihten\u015fteyn"
     ],
+    "name:gcr_x_preferred":[
+        "Liechtenstein"
+    ],
     "name:gla_x_preferred":[
         "Liechtenstein"
     ],
@@ -308,6 +344,12 @@
     ],
     "name:gom_x_preferred":[
         "\u0932\u093f\u0902\u091a\u0947\u0928\u0938\u094d\u091f\u093e\u0907\u0928"
+    ],
+    "name:got_x_preferred":[
+        "\ud800\udf3b\ud800\udf39\ud800\udf3f\ud800\udf37\ud800\udf44\ud800\udf30\ud800\udf43\ud800\udf44\ud800\udf30\ud800\udf39\ud800\udf3d\ud800\udf43"
+    ],
+    "name:gpe_x_preferred":[
+        "Liechtenstein"
     ],
     "name:grn_x_preferred":[
         "Liechytente\u0129"
@@ -370,6 +412,9 @@
     ],
     "name:hye_x_variant":[
         "\u053c\u056b\u056d\u057f\u0565\u0576\u0577\u057f\u0565\u0575\u0576"
+    ],
+    "name:hyw_x_preferred":[
+        "\u053c\u056b\u056d\u0569\u0568\u0576\u0577\u0569\u0561\u0575\u0576"
     ],
     "name:ibo_x_preferred":[
         "Liechtenstein"
@@ -452,6 +497,9 @@
     "name:khm_x_preferred":[
         "\u179b\u17b7\u1785\u1791\u17c1\u1793\u179f\u17d2\u178f\u17c2\u1793"
     ],
+    "name:khm_x_variant":[
+        "\u179b\u17b7\u1785\u178f\u17b7\u1793\u179f\u17d2\u178f\u17b6\u1789"
+    ],
     "name:kik_x_preferred":[
         "Lishenteni"
     ],
@@ -522,6 +570,9 @@
     "name:liv_x_preferred":[
         "Liechtenstein"
     ],
+    "name:lld_x_preferred":[
+        "Liechtenstein"
+    ],
     "name:lmo_x_preferred":[
         "Liechtenstein"
     ],
@@ -539,6 +590,9 @@
     ],
     "name:lzh_x_preferred":[
         "\u5217\u652f\u6566\u58eb\u767b"
+    ],
+    "name:mad_x_preferred":[
+        "Liechtenstein"
     ],
     "name:mal_x_preferred":[
         "\u0d32\u0d3f\u0d15\u0d4d\u0d31\u0d4d\u0d31\u0d7b\u200c\u0d38\u0d4d\u0d31\u0d4d\u0d31\u0d48\u0d7b"
@@ -558,6 +612,9 @@
     "name:mhr_x_preferred":[
         "\u041b\u0438\u0445\u0442\u0435\u043d\u0448\u0442\u0435\u0439\u043d"
     ],
+    "name:min_x_preferred":[
+        "Liechtenstein"
+    ],
     "name:mkd_x_preferred":[
         "\u041b\u0438\u0445\u0442\u0435\u043d\u0448\u0442\u0430\u0458\u043d"
     ],
@@ -569,6 +626,9 @@
     ],
     "name:mlt_x_preferred":[
         "Liechtenstein"
+    ],
+    "name:mni_x_preferred":[
+        "\uabc2\uabe9\uabc6\uabc7\uabe6\uabdf\uabc1\uabed\uabc7\uabe9\uabdf"
     ],
     "name:mon_x_preferred":[
         "\u041b\u0438\u0445\u0442\u0435\u043d\u0448\u0442\u0435\u0439\u043d"
@@ -602,6 +662,9 @@
     ],
     "name:nav_x_preferred":[
         "\u0141\u00ed\u00edhtensain"
+    ],
+    "name:nav_x_variant":[
+        "Ts\u00e9\u0142gaii Bine\u02bcadziihii"
     ],
     "name:nde_x_preferred":[
         "Liechtenstein"
@@ -701,6 +764,9 @@
     "name:pnb_x_preferred":[
         "\u0644\u06cc\u062e\u062a\u0646\u0634\u0679\u0627\u06cc\u0646"
     ],
+    "name:pnb_x_variant":[
+        "\u0644\u062e\u0679\u0646\u0634\u0679\u0627\u0626\u0646"
+    ],
     "name:pnt_x_preferred":[
         "\u039b\u03b9\u03c7\u03c4\u03b5\u03bd\u03c3\u03c4\u03ac\u03b9\u03bd"
     ],
@@ -721,6 +787,9 @@
         "\u0644\u06cc\u062e\u062a\u0646 \u0627\u0634\u062a\u0627\u06cc\u0646"
     ],
     "name:que_x_preferred":[
+        "Liechtenstein"
+    ],
+    "name:rmy_x_preferred":[
         "Liechtenstein"
     ],
     "name:roh_x_preferred":[
@@ -756,6 +825,9 @@
     "name:sgs_x_preferred":[
         "Lichten\u0161teins"
     ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u101c\u102d\u1075\u103a\u1088\u1010\u102d\u107c\u103a\u1087\u101e\u1010\u1062\u1086\u1087"
+    ],
     "name:sin_x_preferred":[
         "\u0dbd\u0dd3\u0da0\u0dca\u0da7\u0db1\u0dca\u0dc3\u0dca\u0da7\u0dd9\u0dba\u0dd2\u0db1\u0dca"
     ],
@@ -771,11 +843,20 @@
     "name:sme_x_preferred":[
         "Liechtenstein"
     ],
+    "name:smn_x_preferred":[
+        "Liechtenstein"
+    ],
     "name:smo_x_preferred":[
         "Liechtenstein"
     ],
+    "name:sms_x_preferred":[
+        "Liechtenstei\u02b9nn"
+    ],
     "name:sna_x_preferred":[
         "Liechtenstein"
+    ],
+    "name:snd_x_preferred":[
+        "\u0644\u06aa\u067d\u0646\u0633\u067d\u0627\u0626\u064a\u0646"
     ],
     "name:som_x_preferred":[
         "Liechtenstein"
@@ -822,6 +903,9 @@
     "name:szl_x_preferred":[
         "Liechtenstein"
     ],
+    "name:szy_x_preferred":[
+        "Liechtenstein"
+    ],
     "name:tam_x_preferred":[
         "\u0bb2\u0bc0\u0b95\u0bcd\u0b95\u0bbf\u0ba9\u0bcd\u0bb8\u0bcd\u0b9f\u0bc8\u0ba9\u0bcd"
     ],
@@ -856,8 +940,17 @@
     "name:tir_x_preferred":[
         "\u120a\u127d\u1270\u1295\u1235\u1273\u12ed\u1295"
     ],
+    "name:tok_x_preferred":[
+        "ma Lisensan"
+    ],
     "name:ton_x_preferred":[
         "Lekitenisaini"
+    ],
+    "name:ton_x_variant":[
+        "Likitenisitaini"
+    ],
+    "name:trv_x_preferred":[
+        "Liechtenstein"
     ],
     "name:tso_x_preferred":[
         "Liechtenstein"
@@ -893,7 +986,8 @@
         "\u0644\u06cc\u062e\u062a\u06cc\u0646\u0633\u062a\u0627\u0626\u0646"
     ],
     "name:urd_x_variant":[
-        "\u0644\u06cc\u0634\u0679\u0646\u0633\u0679\u0627\u0626\u0646"
+        "\u0644\u06cc\u0634\u0679\u0646\u0633\u0679\u0627\u0626\u0646",
+        "\u0644\u062e\u0679\u0646\u0634\u062a\u0627\u0626\u0646"
     ],
     "name:uzb_x_preferred":[
         "Lixtenshteyn"
@@ -1179,7 +1273,7 @@
         "naturalearth",
         "quattroshapes"
     ],
-    "wof:geomhash":"13da64382ed88cbca569565a9ede2fbf",
+    "wof:geomhash":"db459e640c5698cc71e017045842b9cb",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -1195,7 +1289,7 @@
         "deu",
         "gsw"
     ],
-    "wof:lastmodified":1684351666,
+    "wof:lastmodified":1690938528,
     "wof:name":"Liechtenstein",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/859/015/51/85901551.geojson
+++ b/data/859/015/51/85901551.geojson
@@ -33,6 +33,9 @@
     "name:arg_x_preferred":[
         "Hinterschellenberg"
     ],
+    "name:ast_x_preferred":[
+        "Hinterschellenberg"
+    ],
     "name:ces_x_preferred":[
         "Hinterschellenberg"
     ],
@@ -165,7 +168,7 @@
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1582343858,
+    "wof:lastmodified":1690938528,
     "wof:name":"Hinterer Schellenberg",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.