### PR TITLE
li concordances, placetype local, and more

### DIFF
--- a/data/856/332/67/85633267.geojson
+++ b/data/856/332/67/85633267.geojson
@@ -1253,6 +1253,7 @@
         "hasc:id":"LI",
         "icao:code":"HB",
         "ioc:id":"LIE",
+        "iso:code":"LI",
         "itu:id":"LIE",
         "loc:id":"n80158592",
         "m49:code":"438",
@@ -1266,6 +1267,7 @@
         "wd:id":"Q347",
         "wk:page":"Liechtenstein"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         85685737
     ],
@@ -1292,7 +1294,7 @@
         "deu",
         "gsw"
     ],
-    "wof:lastmodified":1694492264,
+    "wof:lastmodified":1695881376,
     "wof:name":"Liechtenstein",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/857/37/85685737.geojson
+++ b/data/856/857/37/85685737.geojson
@@ -716,7 +716,10 @@
         85633267
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "iso:code_pseudo":"LI"
+    },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:coterminous":[
         85633267
     ],
@@ -738,7 +741,7 @@
         "deu",
         "gsw"
     ],
-    "wof:lastmodified":1694493173,
+    "wof:lastmodified":1695884477,
     "wof:name":"Liechtenstein",
     "wof:parent_id":85633267,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.